### PR TITLE
Add separate logger class

### DIFF
--- a/Sentral/SentralDebugConsole/Program.cs
+++ b/Sentral/SentralDebugConsole/Program.cs
@@ -7,12 +7,16 @@ namespace SentralDebugConsole;
 
 internal class Program
 {
+    static UILogger logger = new();
+
     static void Main(string[] args)
     {
         Console.WriteLine("\u001b]0;Control Central\u0007");
         var server = new TcpServer(8000);
 
-        server.LogMessage += OnLogMessageReceived;
+        server.AttachLogger(logger);
+
+        logger.LogMessageEvent += OnLogMessageReceived;
         server.RequestReceived += HandleRequest;
 
         server.Start();
@@ -21,7 +25,7 @@ internal class Program
         Console.ReadKey(true);
 
         server.Stop();
-        server.LogMessage -= OnLogMessageReceived;
+        logger.LogMessageEvent -= OnLogMessageReceived;
         server.RequestReceived -= HandleRequest;
     }
 

--- a/Sentral/SentralLibrary/UILogger.cs
+++ b/Sentral/SentralLibrary/UILogger.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SentralLibrary;
+public class UILogger
+{
+    public event EventHandler<string>? LogMessageEvent;
+
+    public void LogMessage(string message)
+    {
+        LogMessageEvent?.Invoke(this, message);
+    }
+}

--- a/Sentral/SentralLibrary/UserData.cs
+++ b/Sentral/SentralLibrary/UserData.cs
@@ -41,18 +41,6 @@ public class UserData
         return $"{ValidityPeriod.start} - {ValidityPeriod.end}";
     }
 
-    public void UpdateCardID(string id)
-    {
-        //TODO check format
-        CardID = id;
-    }
-
-    public bool VerifyUser(string cardID, string cardPin)
-    {
-        //TODO check requirements on this
-        return cardID == CardID && cardPin == this.CardPin;
-    }
-
     private string GeneratePin()
     {
         int number = random.Next(0, 10000);


### PR DESCRIPTION
Separates the logger event from tcp server class to its own class. UI can now subscribe to a single event after attaching its logger to the specified class that has logging capabilities.